### PR TITLE
feat(tactic/gptf/backends/openai) add no buffer flag to curl

### DIFF
--- a/src/tactic/gptf/backends/openai.lean
+++ b/src/tactic/gptf/backends/openai.lean
@@ -79,6 +79,7 @@ pure {
   cmd := "curl",
   args := [
          "--silent"
+      ,  " -N"
       ,  "-u"
       , format.to_string $ format!":{api_key}"
       ,  "-X"


### PR DESCRIPTION
When using gptf I was regularly getting errors like
```
(23) Failed writing body
(23) Failed writing body
(23) Failed writing body
```
in the Lean server errors tab (this moved the focus of vscode to that tab so was quite annoying).

Disabling buffering of curl output (with "-N") (as per  https://stackoverflow.com/a/35579024/2105639) seemed to fix this problem for me (on Windows but it seems this curl option is platform independent).