### PR TITLE
feat(tactic/gptf/utils/util) JSON escape double quotes

### DIFF
--- a/src/tactic/gptf/utils/util.lean
+++ b/src/tactic/gptf/utils/util.lean
@@ -77,7 +77,7 @@ string.intercalate (⟨['\t']⟩ : string) (consume_spaces <$> strs)
 
 meta def postprocess_tactic_state : tactic_state → tactic string := λ ts, do
   let main : tactic string := do {
-    let ts_str := ts.to_format.to_string,
+    let ts_str := "\\\"".intercalate (ts.to_format.to_string.split (= '"')),
     tabbed_ts_str ← do {
       if (num_goals' ts).get_or_else 0 ≤ 1
       then pure $ ts_str.replace_char '\n' '\t'


### PR DESCRIPTION
For me goal states including quotes like
```lean
example : "1" ≠ "2" :=
begin
   gptf
end
```
failed due to double quotes messing up the string passed to curl, so this PR JSON escapes those quotes at some point.
Maybe there is a better place to make this replacement, I'm not sure?
Fixes #2

This example is a bit silly, but this also happens when dealing with auto_params
```lean
meta def tactic.tt : tactic unit := `[refl]
structure t := (n : ℕ) (h : n = n . tactic.tt)
def a : t := ⟨1⟩
example : a = a :=
begin
  cases a,
gptf,
end
```